### PR TITLE
Enable CONFIG_USB_KDB and CONFIG_USB_MOUSE to support some special devices

### DIFF
--- a/debian/config/config
+++ b/debian/config/config
@@ -740,8 +740,8 @@ CONFIG_HID_SENSOR_HUB=m
 CONFIG_HID_PID=y
 CONFIG_USB_HIDDEV=y
 #. These are for HID Boot Protocol, not full HID
-# CONFIG_USB_KBD is not set
-# CONFIG_USB_MOUSE is not set
+CONFIG_USB_KBD=m
+CONFIG_USB_MOUSE=m
 
 ##
 ## file: drivers/hsi/Kconfig


### PR DESCRIPTION
Enable CONFIG_USB_KDB and CONFIG_USB_MOUSE to support some special devices, such as CNTouch Touch Device (294e:1001).
